### PR TITLE
Required 'revision' statements / editorial / 'must' added back in

### DIFF
--- a/ietf-voucher-request.yang
+++ b/ietf-voucher-request.yang
@@ -11,13 +11,13 @@ module ietf-voucher-request {
 
   import ietf-voucher {
     prefix vch;
-    description "This module defines the format for a voucher,
-        which is produced by a pledge's manufacturer or
-        delegate (MASA) to securely assign a pledge to
-        an 'owner', so that the pledge may establish a secure
-        connection to the owner's network infrastructure";
+    description "This module defines the format for a Voucher,
+        which is produced by a Pledge's manufacturer or
+        delegate (MASA) to securely assign a Pledge to
+        an 'Owner', so that the Pledge may establish a secure
+        connection to the Owner's network infrastructure";
 
-    reference "RFC XXXX: Voucher Artifact for
+    reference "RFC XXXX: A Voucher Artifact for
                Bootstrapping Protocols";
   }
 
@@ -36,47 +36,53 @@ module ietf-voucher-request {
      Author:   Toerless Eckert
                <mailto:tte@cs.fau.de>
      Author:   Qiufang Ma
-               <mailto:maqiufang1@huawei.com>";
+               <mailto:maqiufang1@huawei.com>
+     Author:   Esko Dijk
+               <mailto:esko.dijk@iotconsultancy.nl>";
 
   description
-   "This module defines the format for a voucher request.
-    It is a superset of the voucher itself.
+   "This module defines the format for a Voucher Request.
+    It is a superset of the Voucher itself.
     It provides content to the MASA for consideration
-    during a voucher request.
+    during a voucher request procedure and subsequent
+    Voucher creation.
+
+    Copyright (c) 2023 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, is permitted pursuant to, and subject to
+    the license terms contained in, the Revised BSD License set
+    forth in Section 4.c of the IETF Trust's Legal Provisions
+    Relating to IETF Documents
+    (https://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC XXXX
+    (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
+    for full legal notices.
 
     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
     'MAY', and 'OPTIONAL' in this document are to be interpreted as
     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
-    they appear in all capitals, as shown here.
+    they appear in all capitals, as shown here.";
 
-     Copyright (c) 2024 IETF Trust and the persons identified as
-     authors of the code.  All rights reserved.
+// RFCEDITOR: please replace XXXX in this entire code fragment
+// with the RFC number assigned and remove this notice.
 
-     Redistribution and use in source and binary forms, with or
-     without modification, is permitted pursuant to, and subject to
-     the license terms contained in, the Revised BSD License set
-     forth in Section 4.c of the IETF Trust's Legal Provisions
-     Relating to IETF Documents
-     (https://trustee.ietf.org/license-info).
+  revision YYYY-MM-DD {
+    description
+     "Updates and additions described by RFC XXXX";
+    reference
+     "RFC XXXX: A Voucher Artifact for Bootstrapping Protocols";
+  }
 
-     This version of this YANG module is part of RFC XXXX
-     (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
-     for full legal notices.
-
-RFCEDITOR: please replace XXXX with the RFC number assigned.
-
-     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
-     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
-     'MAY', and 'OPTIONAL' in this document are to be interpreted as
-     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
-     they appear in all capitals, as shown here.";
-
-  revision "YYYY-MM-DD" {
+  revision 2021-05-20 {
     description
      "Initial version";
     reference
-     "RFC XXXX: Bootstrapping Remote Secure Key Infrastructure";
+      "RFC 8995: Bootstrapping Remote Secure Key Infrastructure
+       (BRSKI)";
   }
 
   grouping voucher-request-grouping {
@@ -98,52 +104,52 @@ RFCEDITOR: please replace XXXX with the RFC number assigned.
 
       refine "assertion" {
         description "Any assertion included in registrar voucher
-              requests SHOULD be ignored by the MASA.";
+                     requests SHOULD be ignored by the MASA.";
       }
     }
 
     leaf prior-signed-voucher-request {
-        type binary;
-        description
-         "If it is necessary to change a voucher, or re-sign and
-          forward a voucher request that was previously provided
-          along a protocol path, then the previously signed
-          voucher SHOULD be included in this field.
+      type binary;
+      description
+       "If it is necessary to change a voucher, or re-sign and
+        forward a voucher request that was previously provided
+        along a protocol path, then the previously signed
+        voucher SHOULD be included in this field.
 
-          For example, a pledge might sign a voucher request
-          with a proximity-registrar-cert, and the registrar
-          then includes it as the prior-signed-voucher-request
-          field.  This is a simple mechanism for a chain of
-          trusted parties to change a voucher request, while
-          maintaining the prior signature information.
+        For example, a pledge might sign a voucher request
+        with a proximity-registrar-cert, and the registrar
+        then includes it as the prior-signed-voucher-request
+        field.  This is a simple mechanism for a chain of
+        trusted parties to change a voucher request, while
+        maintaining the prior signature information.
 
-          The Registrar and MASA MAY examine the prior signed
-          voucher information for the
-          purposes of policy decisions. The MASA SHOULD remove all
-          prior-signed-voucher-request information when
-          signing a voucher for imprinting so as to minimize
-          the final voucher size.";
+        The Registrar and MASA MAY examine the prior signed
+        voucher information for the
+        purposes of policy decisions. The MASA SHOULD remove
+        all prior-signed-voucher-request information when
+        signing a voucher for imprinting so as to minimize
+        the final voucher size.";
     }
 
     leaf proximity-registrar-cert {
-        type binary;
-        description
-          "An X.509 v3 certificate structure as specified by
-           RFC 5280, Section 4 encoded using the ASN.1
-           distinguished encoding rules (DER), as specified
-           in [ITU.X690.1994].
+      type binary;
+      description
+       "An X.509 v3 certificate structure as specified by
+        RFC 5280, Section 4 encoded using the ASN.1
+        distinguished encoding rules (DER), as specified
+        in [ITU.X690.1994].
 
-           The first certificate in the Registrar TLS server
-           certificate_list sequence  (the end-entity TLS
-           certificate, see [RFC8446]) presented by the Registrar
-           to the Pledge.
-           This MUST be populated in a Pledge's voucher request
-           when a proximity assertion is requested.";
+        The first certificate in the Registrar TLS server
+        certificate_list sequence  (the end-entity TLS
+        certificate, see [RFC8446]) presented by the Registrar
+        to the Pledge.
+        This MUST be populated in a Pledge's voucher request
+        when a proximity assertion is requested.";
     }
 
     leaf proximity-registrar-pubk {
-        type binary;
-        description
+      type binary;
+      description
         "The proximity-registrar-pubk replaces
          the proximity-registrar-cert in constrained uses of
          the voucher-request.
@@ -159,8 +165,8 @@ RFCEDITOR: please replace XXXX with the RFC number assigned.
     }
 
     leaf proximity-registrar-pubk-sha256 {
-        type binary;
-        description
+      type binary;
+      description
         "The proximity-registrar-pubk-sha256
          is an alternative to both
          proximity-registrar-pubk and pinned-domain-cert.
@@ -178,74 +184,73 @@ RFCEDITOR: please replace XXXX with the RFC number assigned.
     }
 
     leaf agent-signed-data {
-        type binary;
-        description
-          "The agent-signed-data field contains a data artifact
-          provided by the Registrar-Agent to the Pledge for
-          inclusion into the voucher request.
+      type binary;
+      description
+       "The agent-signed-data field contains a data artifact
+        provided by the Registrar-Agent to the Pledge for
+        inclusion into the voucher request.
 
-          This artifact is signed by the Registrar-Agent and contains
-          data, which can be verified by the pledge and the registrar.
-          This data contains the pledge's serial-number and a
-          created-on information of the agent-signed-data.
+        This artifact is signed by the Registrar-Agent and contains
+        data, which can be verified by the pledge and the registrar.
+        This data contains the pledge's serial-number and a
+        created-on information of the agent-signed-data.
 
-          The format is intentionally defined as binary to allow
-          the document using this leaf to determine the encoding.";
+        The format is intentionally defined as binary to allow
+        the document using this leaf to determine the encoding.";
     }
 
     leaf agent-provided-proximity-registrar-cert {
-        type binary;
-        description
-          "An X.509 v3 certificate structure, as specified by
-           RFC 5280, Section 4, encoded using the ASN.1
-           distinguished encoding rules (DER), as specified
-           in ITU X.690.
-           The first certificate in the registrar TLS server
-           certificate_list sequence (the end-entity TLS
-           certificate; see RFC 8446) presented by the
-           registrar to the registrar-agent and provided to
-           the pledge.
-           This MUST be populated in a pledge's voucher-request
-           when an agent-proximity assertion is requested.";
-        reference
-          "ITU X.690: Information Technology - ASN.1 encoding
-           rules: Specification of Basic Encoding Rules (BER),
-           Canonical Encoding Rules (CER) and Distinguished
-           Encoding Rules (DER)
-           RFC 5280: Internet X.509 Public Key Infrastructure
-           Certificate and Certificate Revocation List (CRL)
-           Profile
-           RFC 8446: The Transport Layer Security (TLS)
-           Protocol Version 1.3";
+      type binary;
+      description
+       "An X.509 v3 certificate structure, as specified by
+        RFC 5280, Section 4, encoded using the ASN.1
+        distinguished encoding rules (DER), as specified
+        in ITU X.690.
+        The first certificate in the registrar TLS server
+        certificate_list sequence (the end-entity TLS
+        certificate; see RFC 8446) presented by the
+        registrar to the registrar-agent and provided to
+        the pledge.
+        This MUST be populated in a pledge's voucher-request
+        when an agent-proximity assertion is requested.";
+      reference
+        "ITU X.690: Information Technology - ASN.1 encoding
+         rules: Specification of Basic Encoding Rules (BER),
+         Canonical Encoding Rules (CER) and Distinguished
+         Encoding Rules (DER)
+         RFC 5280: Internet X.509 Public Key Infrastructure
+         Certificate and Certificate Revocation List (CRL)
+         Profile
+         RFC 8446: The Transport Layer Security (TLS)
+         Protocol Version 1.3";
     }
 
     leaf agent-sign-cert {
-        type binary;
-        description
-          "An X.509 v3 certificate structure, as specified by
-           RFC 5280, Section 4, encoded using the ASN.1
-           distinguished encoding rules (DER), as specified
-           in ITU X.690.
-           This certificate can be used by the pledge,
-           the registrar, and the MASA to verify the signature
-           of agent-signed-data. It is an optional component
-           for the pledge-voucher request.
-           This MUST be populated in a registrar's
-           voucher-request when an agent-proximity assertion
-           is requested.";
-        reference
-          "ITU X.690: Information Technology - ASN.1 encoding
-           rules: Specification of Basic Encoding Rules (BER),
-           Canonical Encoding Rules (CER) and Distinguished
-           Encoding Rules (DER)
-           RFC 5280: Internet X.509 Public Key Infrastructure
-           Certificate and Certificate Revocation List (CRL)
-           Profile";
+      type binary;
+      description
+        "An X.509 v3 certificate structure, as specified by
+         RFC 5280, Section 4, encoded using the ASN.1
+         distinguished encoding rules (DER), as specified
+         in ITU X.690.
+         This certificate can be used by the pledge,
+         the registrar, and the MASA to verify the signature
+         of agent-signed-data. It is an optional component
+         for the pledge-voucher request.
+         This MUST be populated in a registrar's
+         voucher-request when an agent-proximity assertion
+         is requested.";
+      reference
+        "ITU X.690: Information Technology - ASN.1 encoding
+         rules: Specification of Basic Encoding Rules (BER),
+         Canonical Encoding Rules (CER) and Distinguished
+         Encoding Rules (DER)
+         RFC 5280: Internet X.509 Public Key Infrastructure
+         Certificate and Certificate Revocation List (CRL)
+         Profile";
     }
   }
 
-  // Top-level statement
-  // Called "voucher" to match RFC8995
+  // Top-level statement: called "voucher" to match RFC8995
   sx:structure voucher {
     uses voucher-request-grouping;
   }

--- a/ietf-voucher.yang
+++ b/ietf-voucher.yang
@@ -31,16 +31,18 @@ module ietf-voucher {
     Author:   Toerless Eckert
               <mailto:tte@cs.fau.de>
     Author:   Qiufang Ma
-              <mailto:maqiufang1@huawei.com>";
+              <mailto:maqiufang1@huawei.com>
+    Author:   Esko Dijk
+              <mailto:esko.dijk@iotconsultancy.nl>";
 
   description
-    "This module defines the format for a voucher, which is
+    "This module defines the format for a Voucher, which is
      produced by a pledge's manufacturer or delegate (MASA)
      to securely assign a pledge to an 'owner', so that the
      pledge may establish a secure connection to the owner's
      network infrastructure.
 
-     Copyright (c) 2024 IETF Trust and the persons identified as
+     Copyright (c) 2023 IETF Trust and the persons identified as
      authors of the code.  All rights reserved.
 
      Redistribution and use in source and binary forms, with or
@@ -54,18 +56,27 @@ module ietf-voucher {
      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
      for full legal notices.
 
-RFCEDITOR: please replace XXXX with the RFC number assigned.
-
      The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
      NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
      'MAY', and 'OPTIONAL' in this document are to be interpreted as
      described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
      they appear in all capitals, as shown here.";
 
+// RFCEDITOR: please replace XXXX in this entire code fragment
+// with the RFC number assigned and remove this notice.
+
   revision YYYY-MM-DD {
     description
-      "updated to support new assertion enumerated type";
-    reference "RFC XXXX Voucher Profile for Bootstrapping Protocols";
+      "Updates and additions described by RFC XXXX";
+    reference
+      "RFC XXXX A Voucher Profile for Bootstrapping Protocols";
+  }
+
+  revision 2018-05-09 {
+    description
+      "Initial version";
+    reference
+      "RFC 8366: Voucher Profile for Bootstrapping Protocols";
   }
 
   grouping voucher-artifact-grouping {
@@ -82,23 +93,23 @@ RFCEDITOR: please replace XXXX with the RFC number assigned.
       }
 
       leaf-list extensions {
-         type union {
-            type uint64;   // when serialized to CBOR with SID
-            type string;    // when serialized to CBOR or JSON
-         }
-         description
-           "A list of extension names that are used in this Voucher
-            file.  Each name is registered with the IANA.  Standard
-            extensions are described in an RFC, while vendor proprietary
-            ones are not.";
+        type union {
+            type uint64;  // when serialized to CBOR with SID
+            type string;  // when serialized to CBOR or JSON
+        }
+        description
+          "A list of extension names that are used in this Voucher
+           file.  Each name is registered with the IANA.  Standard
+           extensions are described in an RFC, while vendor proprietary
+           ones are not.";
       }
 
       leaf manufacturer-private {
         type binary;
-         description
-           "In CBOR serialization, this is a CBOR bstr containing any valid CBOR that
-            the manufacturer wishes to share with it's Pledge.  In JSON serializations,
-            this contains additional JSON instead, and it is base64URL encoded.";
+        description
+          "In CBOR serialization, this is a CBOR bstr containing any valid CBOR that
+           the manufacturer wishes to share with its pledge.  In JSON serializations,
+           this contains additional JSON instead, and it is base64URL encoded.";
       }
 
       leaf assertion {
@@ -180,26 +191,26 @@ RFCEDITOR: please replace XXXX with the RFC number assigned.
         leaf pinned-domain-cert {
           type binary;
           description
-            "An X.509 v3 certificate structure, as specified by
-           RFC 5280, using Distinguished Encoding Rules (DER)
-           encoding, as defined in ITU-T X.690.
+           "An X.509 v3 certificate structure, as specified by
+            RFC 5280, using Distinguished Encoding Rules (DER)
+            encoding, as defined in ITU-T X.690.
 
-           This certificate is used by a pledge to trust a Public Key
-           Infrastructure in order to verify a domain certificate
-           supplied to the pledge separately by the bootstrapping
-           protocol.  The domain certificate MUST have this
-           certificate somewhere in its chain of certificates.
-           This certificate MAY be an end-entity certificate,
-           including a self-signed entity.";
+            This certificate is used by a pledge to trust a Public Key
+            Infrastructure in order to verify a domain certificate
+            supplied to the pledge separately by the bootstrapping
+            protocol.  The domain certificate MUST have this
+            certificate somewhere in its chain of certificates.
+            This certificate MAY be an end-entity certificate,
+            including a self-signed entity.";
           reference
-          "RFC 5280:
+            "RFC 5280:
              Internet X.509 Public Key Infrastructure Certificate
              and Certificate Revocation List (CRL) Profile.
-           ITU-T X.690:
-              Information technology - ASN.1 encoding rules:
-              Specification of Basic Encoding Rules (BER),
-              Canonical Encoding Rules (CER) and Distinguished
-              Encoding Rules (DER).";
+             ITU-T X.690:
+             Information technology - ASN.1 encoding rules:
+             Specification of Basic Encoding Rules (BER),
+             Canonical Encoding Rules (CER) and Distinguished
+             Encoding Rules (DER).";
         }
         leaf pinned-domain-pubk {
           type binary;
@@ -207,7 +218,7 @@ RFCEDITOR: please replace XXXX with the RFC number assigned.
             "The pinned-domain-pubk may replace the
              pinned-domain-cert in constrained uses of
              the voucher. The pinned-domain-pubk
-             is the Raw Public Key of the Registrar.
+             is the Raw Public Key of the registrar.
              This field is encoded as a Subject Public Key Info block
              as specified in RFC7250, in section 3.
              The ECDSA algorithm MUST be supported.
@@ -246,12 +257,11 @@ RFCEDITOR: please replace XXXX with the RFC number assigned.
       }
       leaf last-renewal-date {
         type yang:date-and-time;
-        // this does not work, the XPath does not evaluate
-        // must '../nonceless/expires-on';
+        must '../expires-on';
         description
-            "The date that the MASA projects to be the last date it
-             will renew a voucher on. This field is merely
-             informative; it is not processed by pledges.
+          "The date that the MASA projects to be the last date
+           it will renew a voucher on. This field is merely
+           informative; it is not processed by pledges.
 
            Circumstances may occur after a voucher is generated that
            may alter a voucher's validity period.  For instance,
@@ -297,26 +307,25 @@ RFCEDITOR: please replace XXXX with the RFC number assigned.
       leaf est-domain {
         type ietf:uri;
         description
-          "The est-domain is a URL from which the Pledge should
-             continue doing enrollment rather than with the
-             Cloud Registrar.
-             The pinned-domain-cert contains a trust-anchor
-             which is to be used to authenticate the server
-             found at this URI.
-            ";
+          "The est-domain is a URL from which the pledge should
+           continue doing enrollment rather than with the
+           cloud registrar.
+           The pinned-domain-cert contains a trust-anchor
+           which is to be used to authenticate the server
+           found at this URI.";
       }
       leaf additional-configuration-url {
         type ietf:uri;
         description
           "The additional-configuration attribute contains a
-             URL to which the Pledge can retrieve additional
-             configuration information.
-             The contents of this URL are manufacturer specific.
-             This is intended to do things like configure
-             a VoIP phone to point to the correct hosted
-             PBX, for example.";
+           URL to which the pledge can retrieve additional
+           configuration information.
+           The contents of this URL are manufacturer specific.
+           This is intended to do things like configure
+           a VoIP phone to point to the correct hosted
+           PBX, for example.";
       }
-      }
+  }
 
   // Top-level statement
   sx:structure voucher {


### PR DESCRIPTION
Restoring the required prior-version 'revision' statements; and some editorial/indenting fixes. Also restores the 'must' statement which now validates without warnings.

See details on revision statements retaining in https://datatracker.ietf.org/doc/html/rfc7950#section-7.1.9 