### PR TITLE
Move 'idevid-issuer' clarifications from cBRSKI to 8366bis. 

### DIFF
--- a/draft-ietf-anima-rfc8366bis.md
+++ b/draft-ietf-anima-rfc8366bis.md
@@ -408,7 +408,7 @@ Bearer Voucher:
 
 # Changes since RFC8366
 
-This document obsoletes {{RFC8366}}
+This document obsoletes {{RFC8366}}.
 
 ## Attempts and motivation to extend RFC8366 {#extendfail}
 
@@ -436,17 +436,61 @@ The result was invalid YANG, with multiple definitions of the core Attributes fr
 After some discussion, it was determined that the _augment_ mechanism did not work for this use case,
 nor did it work better when the {{RFC8040}} "yang-data" extension was replaced with the {{RFC8791}} "structure" extension.
 
-After significant discussion the decision was made to simply roll all of the needed extensions  into this document.
+After significant discussion the decision was made to simply roll all of the needed extensions into this document.
 
 # Updates to RFC8995
 
-This document therefore represents a merge of YANG definitions from {{RFC8366}}, the Voucher Request from {{BRSKI}}, and extensions to each of these from {{cBRSKI}}, {{CLOUD}} and {{PRM}}.
-The difficulty with this approach is that the semantics of the definitions needed for the other documents is not included in this document, but rather in the respective other documents.
+This document represents a merge of YANG definitions of the Voucher from {{RFC8366}}, the Voucher Request from {{BRSKI}}, and extensions to each of these from {{cBRSKI}}, {{CLOUD}} and {{PRM}}.
+The difficulty with this approach is that the semantics of the definitions needed for the other documents are not included in this document, but rather in the respective other documents.
 
-The voucher-request definition that was in {{BRSKI}} sections 3.2 (tree diagram) and 3.4  (YANG module) is now included in this document.
-There is a change to the voucher-request: the idevid-issuer MUST be included in the Registrar Voucher Request (RVR).
-Like the serial-number, the idevid-issuer is to be taken from client certificate.
-In some varations of BRSKI, such as {{PRM}} there is no direct TLS connection between Pledge and Registrar.  Therefore the Pledge's IDevID certificate can not be extracted from the TLS connection, so those variations document a different channel binding process.
+## Updates to the use of `idevid-issuer` {#updates-idevid-issuer}
+
+The `voucher-request` module definition that was in {{BRSKI}} Sections 3.2 (tree diagram) and 3.4 (YANG module) is now included in this document.
+There is a change to it: the '`idevid-issuer`' Attribute MUST be included in a Registrar Voucher Request (RVR).
+Like the '`serial-number`' value in the RVR, the '`idevid-issuer`' value in the RVR is to be taken from the Pledge's (IDevID) client certificate.
+In some variations of BRSKI, such as {{PRM}}, there is no direct TLS connection between Pledge and Registrar.  Therefore the Pledge's IDevID certificate cannot be extracted from the TLS connection, so those variations define a different channel binding process and may deviate from the above requirement.
+
+## Clarifications on the use of `idevid-issuer`
+
+{{RFC8366}} and {{BRSKI}} define the '`idevid-issuer`' attribute for the '`voucher`' and '`voucher-request`' modules (respectively), but they summarily explain when to use it, and why it is used.
+
+The '`idevid-issuer`' Attribute is provided so that the serial number to which the issued Voucher pertains can be relative to the entity that issued the Pledge's IDevID.
+In most cases there is a one to one relationship between the trust anchor that signs Vouchers (and is trusted by the Pledge), and the Certification Authority that signs the IDevID.
+In that case, the '`serial-number`' in the Voucher Data must refer to the same device as the serial number that is in the IDevID certificate (in the '`serialNumber`' element of type '`X520SerialNumber`' per {{Section 2.3.1 of BRSKI}}).
+
+However, there are situations where the one to one relationship may be broken.
+This occurs whenever a manufacturer has a common MASA, but different products (on different assembly lines) are produced with identical serial numbers.
+A system of serial numbers which is just a simple counter is a good example of this.
+A system of serial numbers where there is some prefix relating the product type does not fit into this, even if the lower digits are a counter.
+
+Another situation occurs when multiple manufacturers share a common MASA.
+In this case, any given serial number in the IDevID certificate may not be unique across all manufacturers.
+
+It is not possible for the Pledge or the Registrar to know which situation applies.
+And because one the above situations may apply, or may occur in the future, there needs to be a contingency to allow uniquely identifying a Pledge regardless of the current or future situation.
+This is realized by the '`idevid-issuer`' Attribute.
+
+It is clarified next, whether or not to include the '`idevid-issuer`' in the PVR, in the RVR and in the Voucher.
+
+Analysis of the situation shows that the Pledge never needs to include '`idevid-issuer`' Attribute in its PVR, because the Pledge's IDevID certificate is available to the Registrar, and the Authority Key Identifier needed to fill this Attribute is contained within that IDevID certificate.
+The Pledge therefore has no need to repeat this.
+
+For the RVR, {{updates-idevid-issuer}} now normatively requires that the '`idevid-issuer`' Attribute must be included.
+
+For the Voucher, {{voucher-yang-module}} normatively requires ("must") that the '`idevid-issuer`' Attribute must be included by a MASA in case the MASA issues a Voucher with a serial number that is known to be not unique within the scope of all the serial numbers represented by the MASA.
+If this rule does not apply, the MASA SHOULD NOT include the '`idevid-issuer`' Attribute in order to achieve a smaller Voucher size.
+
+## Clarifications on the format of `idevid-issuer`
+
+{{RFC8366}} and {{BRSKI}} were not fully clear on the required binary format of the '`idevid-issuer`' Attribute.
+This gave rise to incompatible implementations.
+
+This section clarifies the format of the '`idevid-issuer`' Attribute, which contains the full Authority Key Identifier from an IDevID certificate.
+The entire Authority Key Identifier object from the certificate i.e. the '`extnValue`' OCTET STRING is to be included, comprising the ASN.1 DER encoding of the '`AuthorityKeyIdentifier`' structure as defined in {{Section 4.2.1.1 of RFC5280}}.
+This includes the ASN.1 DER encoding of the SEQUENCE as well as the OCTET STRING element (tagged 0) that is named '`keyIdentifier`' with type '`KeyIdentifier`'.
+
+Note that per {{IDEVID}}, only the first optional element named '`keyIdentifier`' is expected to be found in an IDevID certificate, not the '`authorityCertIssuer`' or the '`authorityCertSerialNumber`'.
+However, because of the above requirement to include the full '`extnValue`' OCTET STRING, even if the non-expected elements would be present, they would be included in the '`idevid-issuer`' value in a Voucher Request or Voucher.
 
 ## Errata closed
 
@@ -604,7 +648,7 @@ using the '`verified`' assertion type, which should satisfy all Pledges.
 ~~~~
 
 The final two examples illustrate a Voucher that includes an (example) extension per {{voucher-ext}}.
-The hypothetical YANG module name of the extension is "`example-my-extension`".
+The hypothetical YANG module name of the extension is '`example-my-extension`'.
 First, a JSON serialization is shown.
 
 ~~~~

--- a/ietf-voucher-request.yang
+++ b/ietf-voucher-request.yang
@@ -106,6 +106,13 @@ module ietf-voucher-request {
         description "Any assertion included in registrar voucher
                      requests SHOULD be ignored by the MASA.";
       }
+
+      refine "idevid-issuer" {
+        description "The idevid-issuer field MUST be included in
+                     a Registrar Voucher Request (RVR) (unless
+                     specified otherwise) per Section 6.1 of
+                     RFC XXXX.";
+      }
     }
 
     leaf prior-signed-voucher-request {


### PR DESCRIPTION
Also apply some editorial updates.