### PR TITLE
Fix 'XPath' term and remove unused SID ellipsis notation

### DIFF
--- a/draft-ietf-anima-rfc8366bis.md
+++ b/draft-ietf-anima-rfc8366bis.md
@@ -670,9 +670,7 @@ Any such changes will be recorded as errata on this document.
 {{RFC9254}} explains how to serialize YANG into CBOR, and for this a series of SID values are required.
 The below SID values are assigned to the '`ietf-voucher`' YANG module elements and are considered normative.
 
-The right column shows the XPath expression for the YANG data node to which the SID value is assigned.
-In the XPath, the ellipsis (`...`) notation is used to abbreviate the structure path '`/ietf-voucher:voucher`'
-to let each entry fit on one line.
+The right column shows the schema-node path expression for the YANG data node to which the SID value is assigned.
 
 ~~~~
 {::include-fold ietf-voucher-sid.txt}
@@ -773,9 +771,7 @@ The '`ietf-voucher-request`' YANG module is derived from the '`ietf-voucher`' mo
 {{RFC9254}} explains how to serialize YANG into CBOR, and for this a series of SID values are required.
 The below SID values are assigned to the '`ietf-voucher-request`' YANG module elements and are considered normative.
 
-The right column shows the XPath expression for the YANG data node to which the SID value is assigned.
-In the XPath, the ellipsis (`...`) notation is used to abbreviate the structure path '`/ietf-voucher-request:voucher`'
-to let each entry fit on one line.
+The right column shows the schema-node path expression for the YANG data node to which the SID value is assigned.
 
 ~~~~
 {::include-fold ietf-voucher-request-sid.txt}


### PR DESCRIPTION
Fix 'XPath' to the correct term schema-node path per RFC 9595; also remove the now unused ellipsis notation in SID tables.